### PR TITLE
multiline support for `brackets`

### DIFF
--- a/texmath.js
+++ b/texmath.js
@@ -152,12 +152,12 @@ texmath.rules = {
         ],
         block: [ 
             {   name: 'math_block_eqno',
-                rex: /\\\[\s*?(.+?)\\\]\s*?\(([^)$\r\n]+?)\)/gmy,
+                rex: /\\\[\s*?([\s\S]+?)\\\]\s*?\(([^)$\r\n]+?)\)/gmy,
                 tmpl: '<section class="eqno"><eqn>$1</eqn><span>($2)</span></section>',
                 tag: '\\['
             },
             {   name: 'math_block',
-                rex: /\\\[(.+?)\\\]/gmy,
+                rex: /\\\[([\s\S]+?)\\\]/gmy,
                 tmpl: '<section><eqn>$1</eqn></section>',
                 tag: '\\['
             }


### PR DESCRIPTION
I add a multiline support for `brackets` mode, because it can not recognize multilines.

### OK (a single line)

```
\[c=\pm\sqrt{a^2+b^2}\]
```

### NG (multilines)

```
\[
c=\pm\sqrt{a^2+b^2}
\]
```
