### PR TITLE
Fix regexp issues caused rendering problems

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ This extension is a comfortable tool for scientists, engineers and students with
 
 View a [test table](https://goessner.github.io/markdown-it-texmath/index.html).
 
-[try it our ...](https://goessner.github.io/markdown-it-texmath/markdown-it-texmath-demo.html)
+[try it out ...](https://goessner.github.io/markdown-it-texmath/markdown-it-texmath-demo.html)
 
 ## Use with `node.js`
 

--- a/texmath.js
+++ b/texmath.js
@@ -153,12 +153,12 @@ texmath.rules = {
         ],
         block: [ 
             {   name: 'math_block_eqno',
-                rex: /\\\[\s*?([\s\S]+?)\\\]\s*?\(([^)$\r\n]+?)\)/gmy,
+                rex: /\\\[\s*?(.+?)\\\]\s*?\(([^)$\r\n]+?)\)/gmy,
                 tmpl: '<section class="eqno"><eqn>$1</eqn><span>($2)</span></section>',
                 tag: '\\['
             },
             {   name: 'math_block',
-                rex: /\\\[([\s\S]+?)\\\]/gmy,
+                rex: /\\\[(.+?)\\\]/gmy,
                 tmpl: '<section><eqn>$1</eqn></section>',
                 tag: '\\['
             }


### PR DESCRIPTION
When using brackets, the current markdown-it-texmath can't render
properly. This change fixes the incorrect regexp.

fix #9