### PR TITLE
fix the bracket and equation issue

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ This extension is a comfortable tool for scientists, engineers and students with
 
 View a [test table](https://goessner.github.io/markdown-it-texmath/index.html).
 
-[try it our ...](https://goessner.github.io/markdown-it-texmath/markdown-it-texmath-demo.html)
+[try it out ...](https://goessner.github.io/markdown-it-texmath/markdown-it-texmath-demo.html)
 
 ## Use with `node.js`
 

--- a/texmath.js
+++ b/texmath.js
@@ -61,7 +61,7 @@ texmath.block = (rule) =>
                 let token = state.push(rule.name, 'math', 0);
                 token.block = true;
                 token.content = res[1];
-                token.info = res[2];
+                token.info = res[res.length-1];
                 token.markup = rule.tag;
             }
             for (let line=begLine, endpos=res.lastIndex-1; line < endLine; line++)
@@ -153,12 +153,12 @@ texmath.rules = {
         ],
         block: [
             {   name: 'math_block_eqno',
-                rex: /\\\[([\s\S]+?)\\\]\s*?\(([^)$\r\n]+?)\)/gmy,
+                rex: /\\\[(((?!\\\]|\\\[)[\s\S])+?)\\\]\s*?\(([^)$\r\n]+?)\)/gmy,
                 tmpl: '<section class="eqno"><eqn>$1</eqn><span>($2)</span></section>',
                 tag: '\\['
             },
             {   name: 'math_block',
-                rex: /\\\[(.+?)\\\]/gmy,
+                rex: /\\\[([\s\S]+?)\\\]/gmy,
                 tmpl: '<section><eqn>$1</eqn></section>',
                 tag: '\\['
             }

--- a/texmath.js
+++ b/texmath.js
@@ -153,12 +153,12 @@ texmath.rules = {
         ],
         block: [ 
             {   name: 'math_block_eqno',
-                rex: /\\\[\s*?([\s\S]+?)\\\]\s*?\(([^)$\r\n]+?)\)/gmy,
+                rex: /\\\[\s*?(.+?)\\\]\s*?\(([^)$\r\n]+?)\)/gmy,
                 tmpl: '<section class="eqno"><eqn>$1</eqn><span>($2)</span></section>',
                 tag: '\\['
             },
             {   name: 'math_block',
-                rex: /\\\[([\s\S]+?)\\\]/gmy,
+                rex: /\\\[(.+?)\\\]/gmy,
                 tmpl: '<section><eqn>$1</eqn></section>',
                 tag: '\\['
             }


### PR DESCRIPTION
you have 2 regexps, one matches equations with an index
on matches equations without an index,

xxxxxx (1)

or 

xxxxxx


the code prioritize the first regexp over the second, then you have more than one lines of equations like:


aaaaa

.... some text ...

bbbbb (1)

Javascript tends to match the longest string possible, so it will treat the above as a single equation, hence the bug.

The fix adds a negative lookahead to exclude \\\[ \\\] patterns from an equation match. This will change the regexp capture index. so I also changed res[2] to res[res.length -1]
