### PR TITLE
fix: error message XSS vulnerability

### DIFF
--- a/texmath.js
+++ b/texmath.js
@@ -107,7 +107,12 @@ texmath.render = function(tex,displayMode,options) {
         res = texmath.katex.renderToString(tex, options);
     }
     catch(err) {
-        res = tex+": "+err.message.replace("<","&lt;");
+        res = `${tex}:${err.message}`
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;")
+          .replace(/"/g, "&quot;")
+          .replace(/'/g, "&#039;");
+        
     }
     return res;
 }


### PR DESCRIPTION
There is a XSS vulnerability around error handling.
Here are some examples.

```
$$"<img/src=./ onerror=alert(location)>
e^{i\theta} = i\sin\thetae^{i\theta}
$$
```

```
$$
e^{i\theta"<img/src=./ onerror=alert(location)>} = \cos\theta + i\sin\thetae^{i\theta} 
$$
```
I made a change to escape tex string.

Thank you!