### PR TITLE
Escape the macros + use the right slash

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -80,7 +80,7 @@ md.render('Euler\'s identity \(e^{i\pi}+1=0\) is a beautiful formula in $\\RR 2$
                                           katexOptions: { macros: {"\\RR": "\\mathbb{R}"} }
                                         });
         document.getElementById('out').innerHTML = 
-            md.render('Euler\'s identity $e^{i\pi}+1=0$ is a beautiful formula in //RR 2.');
+            md.render('Euler\'s identity $e^{i\pi}+1=0$ is a beautiful formula in $\\RR 2$.');
     })
   </script>
 </body>


### PR DESCRIPTION
The in-Browser macro should reflect the JavaScript format.
Otherwise it doesn't work on my Chromebook:

![image](https://user-images.githubusercontent.com/74717106/107143528-42878a80-693e-11eb-97e2-9bc119b798cb.png)

This probably was a thinko + a typo.