### PR TITLE
Fix documentation for how to use in NPM

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,7 @@ npm install markdown-it-texmath
 ```
 Use it with JavaScript.
 ```js
-const tm = require('../texmath.js');
+const tm = require('markdown-it-texmath');
 const md = require('markdown-it')({html:true})
                   .use(tm, { engine: require('katex'),
                              delimiters: 'dollars',


### PR DESCRIPTION
The `require` statement was written from the perspective of the `test` directory, but a user of this package from NPM will want to `require('markdown-it-texmath')` directly, given the definition of `main` in `package.json`.