### PR TITLE
fix bug in level - the code increases the level by 1 but doesn't reduce it by 1

### DIFF
--- a/texmath.js
+++ b/texmath.js
@@ -94,7 +94,7 @@ texmath.block = (rule) =>
             if (parentType === 'blockquote') // remove all leading '>' inside multiline formula
                 match[1] = match[1].replace(/(\n*?^(?:\s*>)+)/gm,'');
             // begin token
-            let token = state.push(rule.name, 'math', 1);  // 'math_block'
+            let token = state.push(rule.name, 'math', 0);  // 'math_block'
             token.block = true;
             token.tag = rule.tag;
             token.markup = '';


### PR DESCRIPTION
This bug might not be so evident if you're just using the html renderer of markdown-it. However, I use markdown-it to parse markdown and create an AST that is then manipulated using slatejs, and to some subtle use of caching is needed to make this performant.    If you look at the similar plugin

https://github.com/iktakahiro/markdown-it-katex/blob/master/index.js

and also

https://github.com/markdown-it/markdown-it-container/blob/master/index.js

you'll see that the third argument that you're pushing onto the state change the level, and the code here doesn't change the level back.  This means that the rest of the document gets parsed with the level being at least 1 too large.    I think you should instead just pass 0 (as is done for math_inline), since there's only one token that gets emitted, rather than an open/close pair.


Thanks.  I hope this is helpful to somobody.   I wish github itself used a proper parser like this one for math in Markdown, since what they are currently doing isn't so good:  https://news.ycombinator.com/item?id=31450597