### PR TITLE
fix bug in map: it is supposed to be the index of the next line, not the current line.

### DIFF
--- a/texmath.js
+++ b/texmath.js
@@ -100,7 +100,7 @@ texmath.block = (rule) =>
             token.markup = '';
             token.content = match[1];
             token.info = match[match.length-1];    // eq.no
-            token.map = [ begLine, curline ];
+            token.map = [ begLine, curline+1 ];
 //            token.hidden = true;
             // end token ... superfluous ...
 


### PR DESCRIPTION
See, e.g., other plugins such as https://github.com/markdown-it/markdown-it-container/blob/master/index.js.  I was working around this in my code.  It's the sort of thing you might not notice if you're just processing markdown to create html.  However, I use markdown-it only to tokenize markdown, then keep track of what markdown produced the given tokens for the purposes of caching, and then it is critically important that the map be correct.