### PR TITLE
Include forward slash in HTML escapes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-it-texmath",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "markdown-it extension for rendering TeX Math",
   "keywords": [
     "TeX",

--- a/texmath.js
+++ b/texmath.js
@@ -10,7 +10,8 @@ function escapeHTML(text) {
         .replace(/</g, "&lt;")
         .replace(/>/g, "&gt;")
         .replace(/"/g, "&quot;")
-        .replace(/'/g, "&#039;");
+        .replace(/'/g, "&apos;")
+        .replace(/\//g, "&sol;");
 }
 
 function texmath(md, options) {


### PR DESCRIPTION
Trying to use your plugin in a web extension causes the Firefox addon review to fail with the following message:


> 1)  Your escape function is not complete, you must escape for " / " as well.
> - lib\markdown-it-texmath\texmath.js line 7

Slash is a special character in HTML though meaningless on its own… Anyways this is the patch I’m using to fix that issue in case it might be of wider interest.