### PR TITLE
fix: inline block brackets

### DIFF
--- a/texmath.js
+++ b/texmath.js
@@ -208,6 +208,12 @@ texmath.$_post = (str,outerSpace,end) => {
 texmath.rules = {
     brackets: {
         inline: [ 
+            {   name: 'math_inline_double',
+                rex: /\\\[([\s\S]+?)\\\]/gy,
+                tmpl: '<section><eqn>$1</eqn></section>',
+                tag: '\\[',
+                displayMode: true
+            },
             {   name: 'math_inline',
                 rex: /\\\((.+?)\\\)/gy,
                 tmpl: '<eq>$1</eq>',


### PR DESCRIPTION
This PR to resolves Issue 49 to support block brackets in the inline mode. Then name math_inline_double reflects the similar approach to double dollars handling.