### PR TITLE
Add support for persistent macros between renders

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -88,6 +88,13 @@ const str = "Euler\'s identity $e^{i\\pi}+1=0$ is a beautiful formula in $\\RR^2
 
 md.render(str);
 ```
+If you want to persist macros between multiple renders, you can pass `macros` to `render()`'s second argument:
+```js
+const macros = {};
+md.render('$$\\gdef\\RR{\\mathbb{R}}$$', { macros });
+console.debug(macros);  // { '\\RR': '\\mathbb{R}' }
+md.render('$$\\RR^2$$', { macros });  // $$\\mathbb{R}^2$$
+```
 
 ## Use in Browser
 ```html

--- a/texmath.js
+++ b/texmath.js
@@ -35,13 +35,28 @@ function texmath(md, options) {
     for (const rule of delimiters.inline) {
         if (!!outerSpace && 'outerSpace' in rule) rule.outerSpace = true;
         md.inline.ruler.before('escape', rule.name, texmath.inline(rule));  // ! important
-        md.renderer.rules[rule.name] = (tokens, idx) => rule.tmpl.replace(/\$1/,texmath.render(tokens[idx].content,!!rule.displayMode,katexOptions));
+        md.renderer.rules[rule.name] = (tokens, idx, _opts, env) => {
+            const options = {
+                ...katexOptions,
+                macros: env.macros || katexOptions.macros,
+            };
+            return rule.tmpl.replace(
+                /\$1/,
+                texmath.render(tokens[idx].content, !!rule.displayMode, options)
+            );
+        };
     }
     // inject block rules to markdown-it
     for (const rule of delimiters.block) {
         md.block.ruler.before('fence', rule.name, texmath.block(rule));  // ! important for ```math delimiters
-        md.renderer.rules[rule.name] = (tokens, idx) => rule.tmpl.replace(/\$2/,escapeHTML(tokens[idx].info))  // equation number .. ?
-                                                                 .replace(/\$1/,texmath.render(tokens[idx].content,true,katexOptions));
+        md.renderer.rules[rule.name] = (tokens, idx, _opts, env) => {
+            const options = {
+                ...katexOptions,
+                macros: env.macros || katexOptions.macros,
+            };
+            return rule.tmpl.replace(/\$2/, escapeHTML(tokens[idx].info))  // equation number .. ?
+                .replace(/\$1/, texmath.render(tokens[idx].content, true, options));
+        };
     }
 }
 


### PR DESCRIPTION
This patch adds support for persisting user-defined macros between renders in markdown-it-texmath.

To persist macros, pass an env object to the `.render()` method:

```js
const macros = { "\\RR": "\\mathbb{R}" };
texmath.render(input, { macros });
```

Macros defined during rendering will update the `macros` object, allowing reuse in subsequent renders.